### PR TITLE
Added support for a bistable relay as a momentary switch having state based on sensor observation

### DIFF
--- a/custom_components/mcp23017/config_flow.py
+++ b/custom_components/mcp23017/config_flow.py
@@ -17,6 +17,7 @@ from .const import (
     CONF_HW_SYNC,
     CONF_MOMENTARY,
     CONF_PULSE_TIME,
+    CONF_SENSOR,
     DEFAULT_I2C_ADDRESS,
     DEFAULT_I2C_BUS,
     DEFAULT_INVERT_LOGIC,
@@ -177,6 +178,7 @@ class Mcp23017OptionsFlowHandler(config_entries.OptionsFlow):
                             CONF_PULSE_TIME, DEFAULT_PULSE_TIME
                         ),
                     ): vol.All(vol.Coerce(int), vol.Range(min=0)),
+                    vol.Optional(CONF_SENSOR): str,
                 }
             )
         return self.async_show_form(step_id="init", data_schema=data_schema)

--- a/custom_components/mcp23017/const.py
+++ b/custom_components/mcp23017/const.py
@@ -14,6 +14,7 @@ CONF_HW_SYNC = "hw_sync"
 
 CONF_MOMENTARY = "momentary"
 CONF_PULSE_TIME = "pulse_time"
+CONF_SENSOR = "sensor"
 
 CONF_FLOW_PLATFORM = "platform"
 CONF_FLOW_PIN_NUMBER = "pin_number"


### PR DESCRIPTION
This changes allows to configure the switch to support bistable relay with the state calculated from specified sensor.
I want to invite you to take a look and encourage you to make the changes you think. My whole automation based on such cases and I would be glad to have such support in an official repo.